### PR TITLE
MM-27316 Add metrics to Mattermost Logr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/francoispqt/gojay v1.2.13
+	github.com/stretchr/testify v1.2.2
 	github.com/wiggin77/cfg v1.0.2
 	github.com/wiggin77/merror v1.0.2
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/logr.go
+++ b/logr.go
@@ -159,7 +159,7 @@ func (logr *Logr) AddTarget(target Target) error {
 		go logr.start()
 
 		if logr.queueSizeGauge != nil {
-			go logr.updateMetrics()
+			go logr.startMetricsUpdater()
 		}
 	})
 	logr.resetLevelCache()
@@ -444,9 +444,9 @@ func (logr *Logr) start() {
 	close(logr.done)
 }
 
-// updateMetrics updates the metrics for any polled values every `MetricsUpdateFreqSecs` seconds until
+// startMetricsUpdater updates the metrics for any polled values every `MetricsUpdateFreqSecs` seconds until
 // logr is closed.
-func (logr *Logr) updateMetrics() {
+func (logr *Logr) startMetricsUpdater() {
 	for {
 		updateFreq := logr.MetricsUpdateFreqMillis
 		if updateFreq == 0 {

--- a/metrics.go
+++ b/metrics.go
@@ -15,8 +15,11 @@ type SizeAndCap struct {
 // TargetMetrics provides a snapshot of a target's metrics such as
 // current queue size and capacity.
 type TargetMetrics struct {
-	Queue       SizeAndCap
-	LoggedCount uint64
+	Queue        SizeAndCap
+	LoggedCount  uint64
+	ErrorCount   uint64
+	DroppedCount uint64
+	BlockedCount uint64
 }
 
 // TargetWithMetrics is a target that provides metrics.

--- a/metrics.go
+++ b/metrics.go
@@ -6,6 +6,8 @@ const (
 	DefMetricsUpdateFreqMillis = 15000 // 15 seconds
 )
 
+// Counter is a simple metrics sink that can only increment a value.
+// Implementations are external to Logr and provided via `MetricsCollector`.
 type Counter interface {
 	// Inc increments the counter by 1. Use Add to increment it by arbitrary non-negative values.
 	Inc()
@@ -13,6 +15,8 @@ type Counter interface {
 	Add(float64)
 }
 
+// Gauge is a simple metrics sink that can receive values and increase or decrease.
+// Implementations are external to Logr and provided via `MetricsCollector`.
 type Gauge interface {
 	// Set sets the Gauge to an arbitrary value.
 	Set(float64)
@@ -22,6 +26,10 @@ type Gauge interface {
 	Sub(float64)
 }
 
+// MetricsCollector provides a way for users of this Logr package to have metrics pushed
+// in an efficient way to any backend, e.g. Prometheus.
+// For each target added to Logr, the supplied MetricsCollector will provide a Gauge
+// and Counters that will be called frequently as logging occurs.
 type MetricsCollector interface {
 	// QueueSizeGauge returns a Gauge that will be updated by the named target.
 	QueueSizeGauge(target string) Gauge

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,57 @@
+package logr
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// SizeAndCap represents the metrics of something that has a current size
+// and capacity such as a channel or buffer.
+type SizeAndCap struct {
+	Size int
+	Cap  int
+}
+
+// TargetMetrics provides a snapshot of a target's metrics such as
+// current queue size and capacity.
+type TargetMetrics struct {
+	Queue       SizeAndCap
+	LoggedCount uint64
+}
+
+// TargetWithMetrics is a target that provides metrics.
+type TargetWithMetrics interface {
+	GetMetrics() TargetMetrics
+}
+
+// Metrics provides a snapshot of Logr metrics, including queue sizes.
+type Metrics struct {
+	MainQueue   SizeAndCap
+	LoggedCount uint64
+	ErrorCount  uint64
+
+	Targets map[string]TargetMetrics
+}
+
+// GetMetrics returns a snapshot of current logging metrics.
+func (logr *Logr) GetMetrics() Metrics {
+	metrics := Metrics{}
+
+	metrics.LoggedCount = atomic.LoadUint64(&logr.loggedCount)
+	metrics.ErrorCount = atomic.LoadUint64(&logr.errorCount)
+	metrics.MainQueue = SizeAndCap{
+		Size: len(logr.in),
+		Cap:  cap(logr.in),
+	}
+	metrics.Targets = make(map[string]TargetMetrics)
+
+	logr.tmux.RLock()
+	defer logr.tmux.RUnlock()
+	for _, target := range logr.targets {
+		if tt, ok := target.(TargetWithMetrics); ok {
+			name := fmt.Sprintf("%v", target)
+			metrics.Targets[name] = tt.GetMetrics()
+		}
+	}
+	return metrics
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,160 @@
+package logr_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mattermost/logr"
+	"github.com/mattermost/logr/format"
+	"github.com/mattermost/logr/target"
+	"github.com/mattermost/logr/test"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	TestTargetName = "test_target"
+)
+
+func TestLogr_SetMetricsCollector(t *testing.T) {
+	formatter := &format.Plain{DisableTimestamp: true, Delim: " | "}
+	filter := &logr.StdFilter{Lvl: logr.Info, Stacktrace: logr.Error}
+
+	t.Run("metrics after AddTarget should fail", func(t *testing.T) {
+		lgr := &logr.Logr{}
+		defer func() {
+			err := lgr.Shutdown()
+			require.NoError(t, err)
+		}()
+
+		// create target
+		buf := &bytes.Buffer{}
+		tgt := target.NewWriterTarget(filter, formatter, buf, 100)
+		tgt.SetName(TestTargetName)
+
+		// add target before adding metrics
+		err := lgr.AddTarget(tgt)
+		require.NoError(t, err)
+
+		collector := test.NewTestMetricsCollector()
+		err = lgr.SetMetricsCollector(collector)
+		require.Error(t, err)
+	})
+
+	t.Run("metrics before AddTarget should pass", func(t *testing.T) {
+		lgr := &logr.Logr{}
+		defer func() {
+			err := lgr.Shutdown()
+			require.NoError(t, err)
+		}()
+
+		// Add metrics before AddTarget
+		collector := test.NewTestMetricsCollector()
+		err := lgr.SetMetricsCollector(collector)
+		require.NoError(t, err)
+
+		// Create target
+		buf := &bytes.Buffer{}
+		tgt := target.NewWriterTarget(filter, formatter, buf, 100)
+		tgt.SetName(TestTargetName)
+
+		err = lgr.AddTarget(tgt)
+		require.NoError(t, err)
+
+		logger := lgr.NewLogger()
+		logger.Info("Say 'hello' to my little friend!")
+		logger.Info("Hasta la vista, baby.")
+
+		err = lgr.Flush()
+		require.NoError(t, err)
+
+		metricsLogr := collector.Get("_logr")
+		metricsTarget := collector.Get(TestTargetName)
+
+		require.EqualValues(t, 2, metricsLogr.Logged)
+		require.EqualValues(t, 2, metricsTarget.Logged)
+
+		require.EqualValues(t, 0, metricsLogr.Errors)
+		require.EqualValues(t, 0, metricsTarget.Errors)
+	})
+
+	t.Run("metrics with failing target", func(t *testing.T) {
+		lgr := &logr.Logr{}
+		defer func() {
+			err := lgr.Shutdown()
+			require.NoError(t, err)
+		}()
+
+		// Add metrics before AddTarget
+		collector := test.NewTestMetricsCollector()
+		err := lgr.SetMetricsCollector(collector)
+		require.NoError(t, err)
+
+		// Create target
+		tgt := test.NewFailingTarget(filter, formatter)
+		tgt.SetName(TestTargetName)
+
+		err = lgr.AddTarget(tgt)
+		require.NoError(t, err)
+
+		logger := lgr.NewLogger()
+		logger.Info("You're gonna need a bigger boat.")
+		logger.Info("I see dead people.")
+
+		err = lgr.Flush()
+		require.NoError(t, err)
+
+		metricsLogr := collector.Get("_logr")
+		metricsTarget := collector.Get(TestTargetName)
+
+		require.EqualValues(t, 2, metricsLogr.Logged)
+		require.EqualValues(t, 0, metricsTarget.Logged)
+
+		require.EqualValues(t, 2, metricsLogr.Errors)
+		require.EqualValues(t, 2, metricsTarget.Errors)
+	})
+
+	t.Run("metrics with multiple targets", func(t *testing.T) {
+		lgr := &logr.Logr{}
+		defer func() {
+			err := lgr.Shutdown()
+			require.NoError(t, err)
+		}()
+
+		// Add metrics before AddTarget
+		collector := test.NewTestMetricsCollector()
+		err := lgr.SetMetricsCollector(collector)
+		require.NoError(t, err)
+
+		// Create targets
+		buf1 := &bytes.Buffer{}
+		buf2 := &bytes.Buffer{}
+		tgt1 := target.NewWriterTarget(filter, formatter, buf1, 100)
+		tgt2 := target.NewWriterTarget(filter, formatter, buf2, 100)
+		tgt1.SetName(TestTargetName + "1")
+		tgt2.SetName(TestTargetName + "2")
+
+		err = lgr.AddTarget(tgt1)
+		require.NoError(t, err)
+		err = lgr.AddTarget(tgt2)
+		require.NoError(t, err)
+
+		logger := lgr.NewLogger()
+		logger.Info("What we've got here is a failure to communicate.")
+		logger.Info("I love the smell of napalm in the morning.")
+
+		err = lgr.Flush()
+		require.NoError(t, err)
+
+		metricsLogr := collector.Get("_logr")
+		metricsTarget1 := collector.Get(TestTargetName + "1")
+		metricsTarget2 := collector.Get(TestTargetName + "2")
+
+		require.EqualValues(t, 2, metricsLogr.Logged)
+		require.EqualValues(t, 2, metricsTarget1.Logged)
+		require.EqualValues(t, 2, metricsTarget2.Logged)
+
+		require.EqualValues(t, 0, metricsLogr.Errors)
+		require.EqualValues(t, 0, metricsTarget1.Errors)
+		require.EqualValues(t, 0, metricsTarget2.Errors)
+	})
+}

--- a/target.go
+++ b/target.go
@@ -75,7 +75,7 @@ func (b *Basic) Start(target Target, rw RecordWriter, filter Filter, formatter F
 	go b.start()
 
 	if b.queueSizeGauge != nil {
-		go b.updateMetrics()
+		go b.startMetricsUpdater()
 	}
 }
 
@@ -183,9 +183,9 @@ func (b *Basic) start() {
 	close(b.done)
 }
 
-// updateMetrics updates the metrics for any polled values every `MetricsUpdateFreqSecs` seconds until
+// startMetricsUpdater updates the metrics for any polled values every `MetricsUpdateFreqSecs` seconds until
 // target is closed.
-func (b *Basic) updateMetrics() {
+func (b *Basic) startMetricsUpdater() {
 	for {
 		updateFreq := b.metricsUpdateFreqMillis
 		if updateFreq == 0 {

--- a/target/file.go
+++ b/target/file.go
@@ -85,8 +85,3 @@ func (f *File) Shutdown(ctx context.Context) error {
 
 	return errs.ErrorOrNil()
 }
-
-// String returns a string representation of this target.
-func (f *File) String() string {
-	return "FileTarget"
-}

--- a/target/syslog.go
+++ b/target/syslog.go
@@ -87,8 +87,3 @@ func (s *Syslog) Write(rec *logr.LogRec) error {
 	}
 	return err
 }
-
-// String returns a string representation of this target.
-func (s *Syslog) String() string {
-	return "SyslogTarget"
-}

--- a/target/writer.go
+++ b/target/writer.go
@@ -40,6 +40,6 @@ func (w *Writer) Write(rec *logr.LogRec) error {
 }
 
 // String returns a string representation of this target.
-func (w *Writer) String() string {
-	return "WriterTarget"
-}
+//func (w *Writer) String() string {
+//	return "WriterTarget"
+//}

--- a/target/writer.go
+++ b/target/writer.go
@@ -38,8 +38,3 @@ func (w *Writer) Write(rec *logr.LogRec) error {
 	_, err = w.out.Write(buf.Bytes())
 	return err
 }
-
-// String returns a string representation of this target.
-//func (w *Writer) String() string {
-//	return "WriterTarget"
-//}

--- a/test/failtarget.go
+++ b/test/failtarget.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"errors"
+
+	"github.com/mattermost/logr"
+)
+
+// FailingTarget is a test target that always fails.
+type FailingTarget struct {
+	logr.Basic
+}
+
+// NewFailingTarget creates a target that always fails.
+func NewFailingTarget(filter logr.Filter, formatter logr.Formatter) *FailingTarget {
+	t := &FailingTarget{}
+	t.Basic.Start(t, t, filter, formatter, 100)
+	return t
+}
+
+// Write simply fails.
+func (ft *FailingTarget) Write(rec *logr.LogRec) error {
+	return errors.New("FailingTarget always fails")
+}

--- a/test/load.go
+++ b/test/load.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"math/rand"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -52,6 +53,7 @@ func DoSomeLogging(cfg DoSomeLoggingCfg) (logged int32, filtered int32) {
 			if cfg.Delay > 0 {
 				time.Sleep(cfg.Delay)
 			}
+			runtime.Gosched()
 		}
 	}
 

--- a/test/metrics.go
+++ b/test/metrics.go
@@ -1,0 +1,148 @@
+package test
+
+import (
+	"sync"
+
+	"github.com/mattermost/logr"
+)
+
+type TestMetrics struct {
+	QueueSize float64
+	Logged    float64
+	Errors    float64
+	Dropped   float64
+	Blocked   float64
+}
+
+type TestMetricsCollector struct {
+	queueSizeGauges map[string]*TestGauge
+	loggedCounters  map[string]*TestCounter
+	errorCounters   map[string]*TestCounter
+	droppedCounters map[string]*TestCounter
+	blockedCounters map[string]*TestCounter
+}
+
+func NewTestMetricsCollector() *TestMetricsCollector {
+	return &TestMetricsCollector{
+		queueSizeGauges: make(map[string]*TestGauge),
+		loggedCounters:  make(map[string]*TestCounter),
+		errorCounters:   make(map[string]*TestCounter),
+		droppedCounters: make(map[string]*TestCounter),
+		blockedCounters: make(map[string]*TestCounter),
+	}
+}
+
+func (c *TestMetricsCollector) Get(target string) TestMetrics {
+	return TestMetrics{
+		QueueSize: c.queueSizeGauges[target].get(),
+		Logged:    c.loggedCounters[target].get(),
+		Errors:    c.errorCounters[target].get(),
+		Dropped:   c.droppedCounters[target].get(),
+		Blocked:   c.blockedCounters[target].get(),
+	}
+}
+
+func (c *TestMetricsCollector) QueueSizeGauge(target string) logr.Gauge {
+	gauge, ok := c.queueSizeGauges[target]
+	if !ok {
+		gauge = &TestGauge{}
+		c.queueSizeGauges[target] = gauge
+	}
+	return gauge
+}
+
+func (c *TestMetricsCollector) LoggedCounter(target string) logr.Counter {
+	counter, ok := c.loggedCounters[target]
+	if !ok {
+		counter = &TestCounter{}
+		c.loggedCounters[target] = counter
+	}
+	return counter
+}
+
+func (c *TestMetricsCollector) ErrorCounter(target string) logr.Counter {
+	counter, ok := c.errorCounters[target]
+	if !ok {
+		counter = &TestCounter{}
+		c.errorCounters[target] = counter
+	}
+	return counter
+}
+
+func (c *TestMetricsCollector) DroppedCounter(target string) logr.Counter {
+	counter, ok := c.droppedCounters[target]
+	if !ok {
+		counter = &TestCounter{}
+		c.droppedCounters[target] = counter
+	}
+	return counter
+}
+
+func (c *TestMetricsCollector) BlockedCounter(target string) logr.Counter {
+	counter, ok := c.blockedCounters[target]
+	if !ok {
+		counter = &TestCounter{}
+		c.blockedCounters[target] = counter
+	}
+	return counter
+}
+
+type TestGauge struct {
+	val float64
+	mux sync.Mutex
+}
+
+func (g *TestGauge) get() float64 {
+	if g == nil {
+		return 0
+	}
+
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	return g.val
+}
+
+func (g *TestGauge) Set(val float64) {
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	g.val = val
+}
+
+func (g *TestGauge) Add(val float64) {
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	g.val += val
+}
+
+func (g *TestGauge) Sub(val float64) {
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	g.val -= val
+}
+
+type TestCounter struct {
+	val float64
+	mux sync.Mutex
+}
+
+func (c *TestCounter) get() float64 {
+	if c == nil {
+		return 0
+	}
+
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	return c.val
+}
+
+func (c *TestCounter) Inc() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	c.val++
+}
+
+func (c *TestCounter) Add(val float64) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	c.val += val
+}


### PR DESCRIPTION
#### Summary
This PR adds metrics gathering to Logr.  Metrics include queue sizes, queue capacities, logged records counts, and error counts.  Metrics are provided by a new API:  `(*Logr).GetMetrics`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27316