### PR TITLE
MM-28051 Logr must handle shutdown without getting initialized

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -65,6 +65,7 @@ func (logr *Logr) SetMetricsCollector(collector MetricsCollector) error {
 	logr.errorCounter, _ = collector.ErrorCounter("_logr")
 
 	logr.metricsOnce.Do(func() {
+		logr.metricsDone = make(chan struct{})
 		go logr.startMetricsUpdater()
 	})
 


### PR DESCRIPTION
#### Summary
During review of PR https://github.com/mattermost/mattermost-server/pull/15313 it was requested to have Logr possibly get initialized only after a license upgrade.  This required changes to mlog lifecycle and its use of Logr.

A side effect of this change is that Logr can be instantiated but not configured or initialized.  It can be asked to collect metrics for Prometheus without being initialized as well.   Finally it can be shutdown without being initalized.  This ticket handles these and ensures clean shutdown of uninitialized Logr.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28051