### PR TITLE
fix race in metrics chan

### DIFF
--- a/logr_test.go
+++ b/logr_test.go
@@ -141,15 +141,16 @@ func TestLogAfterShutdown(t *testing.T) {
 }
 
 func TestRemoveTarget(t *testing.T) {
-	buf := &bytes.Buffer{}
 	formatter := &format.Plain{DisableTimestamp: true, Delim: " | "}
 	filter := &logr.StdFilter{Lvl: logr.Info, Stacktrace: logr.Error}
 
-	target1 := test.NewSlowTarget(filter, formatter, buf, 3000)
+	buf1 := &bytes.Buffer{}
+	target1 := test.NewSlowTarget(filter, formatter, buf1, 3000)
 	target1.SetName("t1")
 	target1.Delay = time.Millisecond * 2
 
-	target2 := test.NewSlowTarget(filter, formatter, buf, 3000)
+	buf2 := &bytes.Buffer{}
+	target2 := test.NewSlowTarget(filter, formatter, buf2, 3000)
 	target2.SetName("t2")
 	target2.Delay = time.Millisecond * 2
 

--- a/metrics.go
+++ b/metrics.go
@@ -64,7 +64,7 @@ func (logr *Logr) SetMetricsCollector(collector MetricsCollector) error {
 	logr.loggedCounter, _ = collector.LoggedCounter("_logr")
 	logr.errorCounter, _ = collector.ErrorCounter("_logr")
 
-	logr.metricsOnce.Do(func() {
+	logr.metricsInitOnce.Do(func() {
 		logr.metricsDone = make(chan struct{})
 		go logr.startMetricsUpdater()
 	})

--- a/test/slowtarget.go
+++ b/test/slowtarget.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"io"
+	"sync"
 	"time"
 
 	"github.com/mattermost/logr"
@@ -14,6 +15,7 @@ type SlowTarget struct {
 	logr.Basic
 	out   io.Writer
 	Delay time.Duration
+	mux   sync.Mutex
 }
 
 // NewSlowTarget creates a new SlowTarget.
@@ -38,6 +40,9 @@ func (st *SlowTarget) Write(rec *logr.LogRec) error {
 	}
 
 	time.Sleep(st.Delay)
+
+	st.mux.Lock()
+	defer st.mux.Unlock()
 
 	_, err = st.out.Write(buf.Bytes())
 	return err


### PR DESCRIPTION

#### Summary
This PR fixes a race when closing a "done" channel for metrics collection.  Close operation is now done in a `sync.Once` which is a better pattern anyway.

