### PR TITLE
Fix build constraint

### DIFF
--- a/targets/syslog_unsupported.go
+++ b/targets/syslog_unsupported.go
@@ -1,4 +1,4 @@
-// +build windows,nacl,plan9
+// +build windows nacl plan9
 
 package targets
 


### PR DESCRIPTION
#### Summary
Fixes the build contraint  (+build at top of file) due to the comma separated platforms causing the the platforms to be AND'ed, thus breaking the build for Windows.

Tiny change - no reviewers needed.

#### Ticket Link
https://github.com/mattermost/focalboard/issues/519