### PR TITLE
fix metrics shutdown

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -132,7 +132,8 @@ func (lgr *Logr) stopMetricsUpdater() {
 	lgr.metricsMux.RLock()
 	defer lgr.metricsMux.RUnlock()
 
-	if lgr.metrics != nil {
+	if lgr.metrics != nil && lgr.metrics.done != nil {
 		close(lgr.metrics.done)
+		lgr.metrics.done = nil
 	}
 }


### PR DESCRIPTION
#### Summary
This PR fixes an issue with metrics collector shutdown where unit test can cause the shutdown to happen more than once, causing a close of a closed channel.

#### Ticket Link
NONE