### PR TITLE
MM-38342  add Zap-like methods for Sugar logger

### DIFF
--- a/field.go
+++ b/field.go
@@ -15,7 +15,7 @@ var (
 	Space   = []byte{' '}
 	Newline = []byte{'\n'}
 	Quote   = []byte{'"'}
-	Colon   = []byte{'"'}
+	Colon   = []byte{':'}
 )
 
 // LogCloner is implemented by `Any` types that require a clone to be provided

--- a/filtercustom_test.go
+++ b/filtercustom_test.go
@@ -27,8 +27,8 @@ func TestCustomLevel(t *testing.T) {
 	filter.Add(LoginLevel, LogoutLevel)
 
 	formatter := &formatters.Plain{Delim: " | "}
-	tgr := targets.NewWriterTarget(buf)
-	err := lgr.AddTarget(tgr, "customLevelTest", filter, formatter, 1000)
+	target := targets.NewWriterTarget(buf)
+	err := lgr.AddTarget(target, "customLevelTest", filter, formatter, 1000)
 	require.NoError(t, err)
 
 	logger := lgr.NewLogger().With(
@@ -74,8 +74,8 @@ func TestLevelIDTooLarge(t *testing.T) {
 	filter.Add(BadLevel)
 
 	formatter := &formatters.Plain{Delim: " | "}
-	tgr := targets.NewWriterTarget(buf)
-	err = lgr.AddTarget(tgr, "levelTest", filter, formatter, 1000)
+	target := targets.NewWriterTarget(buf)
+	err = lgr.AddTarget(target, "levelTest", filter, formatter, 1000)
 	require.NoError(t, err)
 
 	logger := lgr.NewLogger().With(logr.String("user", "Bob"), logr.String("role", "admin"))

--- a/filterstd.go
+++ b/filterstd.go
@@ -11,6 +11,7 @@ type StdFilter struct {
 // is enabled for this filter.
 func (lt StdFilter) GetEnabledLevel(level Level) (Level, bool) {
 	enabled := level.ID <= lt.Lvl.ID
+	stackTrace := level.ID <= lt.Stacktrace.ID
 	var levelEnabled Level
 
 	if enabled {
@@ -33,6 +34,11 @@ func (lt StdFilter) GetEnabledLevel(level Level) (Level, bool) {
 			levelEnabled = level
 		}
 	}
+
+	if stackTrace {
+		levelEnabled.Stacktrace = true
+	}
+
 	return levelEnabled, enabled
 }
 

--- a/sugar.go
+++ b/sugar.go
@@ -117,3 +117,80 @@ func (s Sugar) Fatalf(format string, args ...interface{}) {
 func (s Sugar) Panicf(format string, args ...interface{}) {
 	s.Logf(Panic, format, args...)
 }
+
+//
+// K/V style
+//
+
+// With returns a new Sugar logger with the specified key/value pairs added to the
+// fields list.
+func (s Sugar) With(keyValuePairs ...interface{}) Sugar {
+	return s.logger.With(s.argsToFields(keyValuePairs)...).Sugar()
+}
+
+// Tracew outputs at trace level with the specified key/value pairs converted to fields.
+func (s Sugar) Tracew(msg string, keyValuePairs ...interface{}) {
+	s.logger.Log(Trace, msg, s.argsToFields(keyValuePairs)...)
+}
+
+// Debugw outputs at debug level with the specified key/value pairs converted to fields.
+func (s Sugar) Debugw(msg string, keyValuePairs ...interface{}) {
+	s.logger.Log(Debug, msg, s.argsToFields(keyValuePairs)...)
+}
+
+// Infow outputs at info level with the specified key/value pairs converted to fields.
+func (s Sugar) Infow(msg string, keyValuePairs ...interface{}) {
+	s.logger.Log(Info, msg, s.argsToFields(keyValuePairs)...)
+}
+
+// Warnw outputs at warn level with the specified key/value pairs converted to fields.
+func (s Sugar) Warnw(msg string, keyValuePairs ...interface{}) {
+	s.logger.Log(Warn, msg, s.argsToFields(keyValuePairs)...)
+}
+
+// Errorw outputs at error level with the specified key/value pairs converted to fields.
+func (s Sugar) Errorw(msg string, keyValuePairs ...interface{}) {
+	s.logger.Log(Error, msg, s.argsToFields(keyValuePairs)...)
+}
+
+// Fatalw outputs at fatal level with the specified key/value pairs converted to fields.
+func (s Sugar) Fatalw(msg string, keyValuePairs ...interface{}) {
+	s.logger.Log(Fatal, msg, s.argsToFields(keyValuePairs)...)
+}
+
+// Panicw outputs at panic level with the specified key/value pairs converted to fields.
+func (s Sugar) Panicw(msg string, keyValuePairs ...interface{}) {
+	s.logger.Log(Panic, msg, s.argsToFields(keyValuePairs)...)
+}
+
+// argsToFields converts an array of args, possibly containing name/value pairs
+// into a []Field.
+func (s Sugar) argsToFields(keyValuePairs []interface{}) []Field {
+	if len(keyValuePairs) == 0 {
+		return nil
+	}
+
+	fields := make([]Field, 0, len(keyValuePairs))
+	count := len(keyValuePairs)
+
+	for i := 0; i < count; {
+		if fld, ok := keyValuePairs[i].(Field); ok {
+			fields = append(fields, fld)
+			i++
+			continue
+		}
+
+		if i == count-1 {
+			s.logger.Error("invalid key/value pair", Any("arg", keyValuePairs[i]))
+		}
+
+		// we should have a key/value pair now. The key must be a string.
+		if key, ok := keyValuePairs[i].(string); !ok {
+			s.logger.Error("invalid key for key/value pair", Int("pos", i))
+		} else {
+			fields = append(fields, Any(key, keyValuePairs[i+1]))
+		}
+		i += 2
+	}
+	return fields
+}

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -1,0 +1,91 @@
+package logr_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/mattermost/logr/v2"
+	"github.com/mattermost/logr/v2/formatters"
+	"github.com/mattermost/logr/v2/targets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSugarLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	sugar, shutdown, err := makeSugar(buf)
+	require.NoError(t, err)
+
+	// Info
+	sugar.Info("Test for info level", "ident1", "ident2", 77)
+
+	// Error with stacktrace
+	sugar.Error("Test for error level", "ident3", "ident4", 33)
+
+	// Debugw
+	sugar.Debugw("Test for error level with name/value pairs", "prop1", "ident6", "prop2", "ident7")
+
+	// Debugw no args
+	sugar.Debugw("Test name/value pairs no args")
+
+	// Debugw invalid args
+	sugar.Debugw("Test name/value pairs invalid args1", 44, "hello")
+
+	// With
+	sugar2 := sugar.With("prop3", "foo", "prop4", "bar")
+	sugar2.Debug("Test With")
+
+	err = shutdown()
+	require.NoError(t, err)
+	data := buf.String()
+
+	// Info
+	assert.Contains(t, data, "test=sugar")
+	assert.Contains(t, data, "Test for info level")
+	assert.Contains(t, data, "ident1")
+	assert.Contains(t, data, "ident2")
+	assert.Contains(t, data, "=77")
+
+	// Error
+	assert.Contains(t, data, "test=sugar")
+	assert.Contains(t, data, "Test for error level")
+	assert.Contains(t, data, "ident3")
+	assert.Contains(t, data, "ident4")
+	assert.Contains(t, data, "=33")
+	assert.Contains(t, data, "logr/sugar_test.go:")
+
+	// Debugw
+	assert.Contains(t, data, "test=sugar")
+	assert.Contains(t, data, "Test for error level with name/value pairs")
+	assert.Contains(t, data, "prop1=ident6")
+	assert.Contains(t, data, "prop2=ident7")
+
+	// Debugw no args
+	assert.Contains(t, data, "test=sugar")
+	assert.Contains(t, data, "Test name/value pairs no args")
+
+	// invalid args
+	assert.Contains(t, data, "invalid key for key/value pair")
+
+	// With
+	assert.Contains(t, data, "test=sugar")
+	assert.Contains(t, data, "Test With")
+	assert.Contains(t, data, "prop3=foo")
+	assert.Contains(t, data, "prop4=bar")
+}
+
+func makeSugar(buf *bytes.Buffer) (logr.Sugar, func() error, error) {
+	formatter := &formatters.Plain{DisableTimestamp: true, Delim: " | "}
+	filter := &logr.StdFilter{Lvl: logr.Debug, Stacktrace: logr.Error}
+	target := targets.NewWriterTarget(buf)
+	lgr, _ := logr.New()
+	err := lgr.AddTarget(target, "sugarTest", filter, formatter, 3000)
+	if err != nil {
+		return logr.Sugar{}, nil, err
+	}
+	sugar := lgr.NewLogger().Sugar(logr.String("test", "sugar"))
+	shutdown := func() error {
+		return lgr.Shutdown()
+	}
+	return sugar, shutdown, nil
+}

--- a/targets/tcp_test.go
+++ b/targets/tcp_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	Server   = "localhost"
-	TestPort = 18066
+	TestPort = 18067
 )
 
 func TestNewTcpTarget(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR adds Zap-like name/value pair APIs to the Sugar logger.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38342