### PR TITLE
Use params.Host over params.IP for syslog config

### DIFF
--- a/targets/syslog.go
+++ b/targets/syslog.go
@@ -1,3 +1,4 @@
+//go:build !windows && !nacl && !plan9
 // +build !windows,!nacl,!plan9
 
 package targets
@@ -19,7 +20,7 @@ type Syslog struct {
 
 // SyslogOptions provides parameters for dialing a syslog daemon.
 type SyslogOptions struct {
-	IP       string `json:"ip,omitempty"` // deprecated
+	IP       string `json:"ip,omitempty"` // deprecated (use Host instead)
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
 	TLS      bool   `json:"tls"`
@@ -55,6 +56,11 @@ func (s *Syslog) Init() error {
 	network := "tcp"
 	var config *tls.Config
 
+	host := s.params.Host
+	if host == "" {
+		host = s.params.IP
+	}
+
 	if s.params.TLS {
 		network = "tcp+tls"
 		config = &tls.Config{InsecureSkipVerify: s.params.Insecure}
@@ -66,7 +72,7 @@ func (s *Syslog) Init() error {
 			config.RootCAs = pool
 		}
 	}
-	raddr := fmt.Sprintf("%s:%d", s.params.IP, s.params.Port)
+	raddr := fmt.Sprintf("%s:%d", host, s.params.Port)
 	if raddr == ":0" {
 		// If no IP:port provided then connect to local syslog.
 		raddr = ""

--- a/targets/syslog_test.go
+++ b/targets/syslog_test.go
@@ -22,7 +22,7 @@ func ExampleSyslog() {
 	filter := &logr.StdFilter{Lvl: logr.Warn, Stacktrace: logr.Error}
 	formatter := &formatters.Plain{Delim: " | "}
 	params := &targets.SyslogOptions{
-		IP:   "localhost",
+		Host: "localhost",
 		Port: 514,
 		Tag:  "logrtest",
 	}


### PR DESCRIPTION
#### Summary
A bug was reported where the params.Host config setting was ignored and only the deprecated params.IP was used.   This PR ensures params.Host takes priority over IP.

#### Ticket Link
NONE