### PR TITLE
Don't allow empty short_message for Gelf formatter

### DIFF
--- a/formatters/gelf.go
+++ b/formatters/gelf.go
@@ -79,7 +79,7 @@ type gelfRecord struct {
 func (gr gelfRecord) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.AddStringKey(GelfVersionKey, GelfVersion)
 	enc.AddStringKey(GelfHostKey, gr.getHostname())
-	enc.AddStringKey(GelfShortKey, gr.Msg())
+	enc.AddStringKey(GelfShortKey, gr.safeMsg("-")) // Gelf requires a non-empty `short_message`
 
 	if gr.level.Stacktrace {
 		frames := gr.StackFrames()
@@ -129,6 +129,15 @@ func (gr gelfRecord) MarshalJSONObject(enc *gojay.Encoder) {
 // IsNil returns true if the gelf record pointer is nil.
 func (gr gelfRecord) IsNil() bool {
 	return gr.LogRec == nil
+}
+
+// safeMsg returns the log record Message field or an alternate string when msg is empty.
+func (gr gelfRecord) safeMsg(alt string) string {
+	s := gr.Msg()
+	if s == "" {
+		s = alt
+	}
+	return s
 }
 
 func (g *Gelf) getHostname() string {


### PR DESCRIPTION
#### Summary
Graylog throws an exception when importing Mattermost audit records in Gelf format due to the `short_message` field being blank.  `short_message` is populated via the Message field of the log record, which is always blank for audit records.  

This PR ensures that field is never blank.

See [discussion here](https://community.mattermost.com/core/pl/w46j8k4syjrhtcoqb9hpjyqb6a).

#### Ticket Link
NONE
