### PR TITLE
WIP: add limit to single log entries (keyed log entries)

### DIFF
--- a/const.go
+++ b/const.go
@@ -31,4 +31,7 @@ const (
 	// DefaultMaxPooledBuffer is the maximum size a pooled buffer can be.
 	// Buffers that grow beyond this size are garbage collected.
 	DefaultMaxPooledBuffer = 1024 * 1024
+
+	// DefaultMaxFieldLength is the maximum size of a String or dmt.Stringer field can be.
+	DefaultMaxFieldLength = 2048
 )

--- a/const.go
+++ b/const.go
@@ -32,6 +32,6 @@ const (
 	// Buffers that grow beyond this size are garbage collected.
 	DefaultMaxPooledBuffer = 1024 * 1024
 
-	// DefaultMaxFieldLength is the maximum size of a String or dmt.Stringer field can be.
-	DefaultMaxFieldLength = 2048
+	// DefaultMaxFieldLength is the maximum size of a String or fmt.Stringer field can be.
+	DefaultMaxFieldLength = -1
 )

--- a/formatter.go
+++ b/formatter.go
@@ -2,6 +2,7 @@ package logr
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"runtime"
 	"strconv"
@@ -26,6 +27,29 @@ const (
 	// TimestampMillisFormat is the format for logging milliseconds UTC
 	TimestampMillisFormat = "Jan _2 15:04:05.000"
 )
+
+// LimitByteSlice discards the bytes from a slice that exceeds the limit
+func LimitByteSlice(b []byte, limit int) []byte {
+	if limit > 0 && limit < len(b) {
+		b = append(b[:limit], []byte("...")...)
+	}
+
+	return b
+}
+
+// LimitString discards the runes from a slice that exceeds the limit
+func LimitString(b string, limit int) string {
+	return string(LimitByteSlice([]byte(b), limit))
+}
+
+type LimitedStringer struct {
+	fmt.Stringer
+	Limit int
+}
+
+func (ls *LimitedStringer) String() string {
+	return LimitString(ls.Stringer.String(), ls.Limit)
+}
 
 type Writer struct {
 	io.Writer

--- a/formatter.go
+++ b/formatter.go
@@ -31,7 +31,9 @@ const (
 // LimitByteSlice discards the bytes from a slice that exceeds the limit
 func LimitByteSlice(b []byte, limit int) []byte {
 	if limit > 0 && limit < len(b) {
-		b = append(b[:limit], []byte("...")...)
+		lb := make([]byte, 0, limit+3)
+		copy(lb, b[:limit])
+		return append(lb, []byte("...")...)
 	}
 
 	return b

--- a/logr.go
+++ b/logr.go
@@ -247,23 +247,26 @@ func (lgr *Logr) SetMetricsCollector(collector MetricsCollector, updateFreqMilli
 // this function either blocks or the log record is dropped, depending on
 // the result of calling `OnQueueFull`.
 func (lgr *Logr) enqueue(rec *LogRec) {
-	// we also limit the message
-	rec.msg = LimitString(rec.msg, lgr.options.maxFieldLen)
+	// check if a limit has been configured
+	if limit := lgr.options.maxFieldLen; limit > 0 {
+		// we limit the message
+		rec.msg = LimitString(rec.msg, limit)
 
-	// then we range over fields to apply the limit
-	for i := range rec.fields {
-		switch rec.fields[i].Type {
-		case StringType:
-			rec.fields[i].String = LimitString(rec.fields[i].String, lgr.options.maxFieldLen)
-		case StringerType:
-			if v, ok := rec.fields[i].Interface.(fmt.Stringer); ok {
-				rec.fields[i].Interface = &LimitedStringer{
-					Stringer: v,
-					Limit:    lgr.options.maxFieldLen,
+		// then we range over fields to apply the limit
+		for i := range rec.fields {
+			switch rec.fields[i].Type {
+			case StringType:
+				rec.fields[i].String = LimitString(rec.fields[i].String, limit)
+			case StringerType:
+				if v, ok := rec.fields[i].Interface.(fmt.Stringer); ok {
+					rec.fields[i].Interface = &LimitedStringer{
+						Stringer: v,
+						Limit:    limit,
+					}
 				}
+			default:
+				// no limits for other field types
 			}
-		default:
-			// no limits for other field types
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -23,6 +23,7 @@ type options struct {
 	metricsCollector        MetricsCollector
 	metricsUpdateFreqMillis int64
 	stackFilter             map[string]struct{}
+	maxFieldLen             int
 }
 
 // MaxQueueSize is the maximum number of log records that can be queued.
@@ -187,6 +188,19 @@ func StackFilter(pkg ...string) Option {
 				l.options.stackFilter[p] = struct{}{}
 			}
 		}
+		return nil
+	}
+}
+
+// MaxFieldLen is the maximum number of characters for a field.
+// If exceeded, remaining bytes will be discarded.
+// Defaults to DefaultMaxFieldLength.
+func MaxFieldLen(size int) Option {
+	return func(l *Logr) error {
+		if size < 0 {
+			return errors.New("size cannot be less than zero")
+		}
+		l.options.maxFieldLen = size
 		return nil
 	}
 }


### PR DESCRIPTION


#### Summary
There are some occurrences where we directly log values provided by users. Some attackers can send large data (eg. queries in the links etc.) and we end up logging them into the file and it can eat the disk space. To avoid that, I tried to add some limiting mechanism into the library. 

I'm not sure whether this would be the best approach, we can review entire server code and limit the entries while calling the log function instead.

I just wanted to get an opinion from you @wiggin77 whether this looks like a "sane" approach or not. So consider this as a Draft PR to discuss.

