### PR TITLE
Add type constraints for Map and Array fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
 
     - name: Add dependencies
       run: |

--- a/fieldapi.go
+++ b/fieldapi.go
@@ -100,11 +100,11 @@ func Millis(key string, val int64) Field {
 }
 
 // Array constructs a field containing a key and array value.
-func Array(key string, val interface{}) Field {
+func Array[S ~[]E, E any](key string, val S) Field {
 	return Field{Key: key, Type: ArrayType, Interface: val}
 }
 
 // Map constructs a field containing a key and map value.
-func Map(key string, val interface{}) Field {
+func Map[M ~map[K]V, K comparable, V any](key string, val M) Field {
 	return Field{Key: key, Type: MapType, Interface: val}
 }

--- a/fieldapi_test.go
+++ b/fieldapi_test.go
@@ -12,3 +12,14 @@ func TestFieldArray(t *testing.T) {
 	type myGenericArray[T any] []T
 	Array("array", myGenericArray[any]{})
 }
+
+func TestFieldMap(t *testing.T) {
+	Map("array", map[string]any{})
+	Map("array", map[int]any{})
+
+	type myMap map[string]string
+	Map("array", myMap{})
+
+	type myGenericMap[K comparable, V any] map[K]V
+	Map("array", myGenericMap[int, any]{})
+}

--- a/fieldapi_test.go
+++ b/fieldapi_test.go
@@ -1,0 +1,14 @@
+package logr
+
+import "testing"
+
+func TestFieldArray(t *testing.T) {
+	Array("array", []string{})
+	Array("array", []any{})
+
+	type myArray []any
+	Array("array", myArray{})
+
+	type myGenericArray[T any] []T
+	Array("array", myGenericArray[any]{})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/logr/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/francoispqt/gojay v1.2.13


### PR DESCRIPTION
#### Summary
By adding type constraints for `Map` and `Array` fields, it's ensured at compile time that no non-array or non-map is passed to these methods.

This is the first introduction of generics in this codebase. I hope it's allowed.

#### Ticket Link
None
