### PR TITLE
[MM-55614] Remove trailing comma from lists

### DIFF
--- a/field.go
+++ b/field.go
@@ -187,16 +187,22 @@ func (f Field) ValueString(w io.Writer, shouldQuote func(s string) bool) error {
 					break arr
 				}
 			}
-			if _, err = w.Write(Comma); err != nil {
-				break arr
+			if i != a.Len()-1 {
+				if _, err = w.Write(Comma); err != nil {
+					break arr
+				}
 			}
 		}
 
 	case MapType:
 		a := reflect.ValueOf(f.Interface)
 		iter := a.MapRange()
+		// Already advance to first element
+		if !iter.Next() {
+			return nil
+		}
 	it:
-		for iter.Next() {
+		for {
 			if _, err = io.WriteString(w, iter.Key().String()); err != nil {
 				break it
 			}
@@ -219,9 +225,15 @@ func (f Field) ValueString(w io.Writer, shouldQuote func(s string) bool) error {
 					break it
 				}
 			}
+
+			if !iter.Next() {
+				break it
+			}
+
 			if _, err = w.Write(Comma); err != nil {
 				break it
 			}
+
 		}
 
 	case UnknownType:

--- a/field_test.go
+++ b/field_test.go
@@ -82,6 +82,61 @@ func TestFieldForAny(t *testing.T) {
 	}
 }
 
+func TestField_Array(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   Field
+		wantW   string
+		wantErr bool
+	}{
+		{name: "nil", field: Array[[]any]("array", nil), wantW: "", wantErr: false},
+		{name: "empty", field: Array("array", []string{}), wantW: "", wantErr: false},
+		{name: "one elements", field: Array("array", []string{"foo"}), wantW: "foo", wantErr: false},
+		{name: "two elements", field: Array("array", []string{"foo", "bar"}), wantW: "foo,bar", wantErr: false},
+		{name: "three elements", field: Array("array", []string{"foo", "bar", "xyz"}), wantW: "foo,bar,xyz", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			if err := tt.field.ValueString(w, nil); (err != nil) != tt.wantErr {
+				t.Errorf("Field.ValueString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotW := w.String(); gotW != tt.wantW {
+				t.Errorf("Field.ValueString() = %v, want %v", gotW, tt.wantW)
+			}
+		})
+	}
+}
+
+func TestField_Map(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   Field
+		wantW   string
+		wantErr bool
+	}{
+		{name: "nil", field: Map[map[string]any]("map", nil), wantW: "", wantErr: false},
+
+		{name: "empty", field: Map("map", map[string]any{}), wantW: "", wantErr: false},
+		{name: "one elements", field: Map("map", map[string]int{"foo": 0}), wantW: "foo=0", wantErr: false},
+		{name: "two elements", field: Map("map", map[string]int{"foo": 0, "bar": 1}), wantW: "foo=0,bar=1", wantErr: false},
+		{name: "three elements", field: Map("map", map[string]int{"foo": 0, "bar": 1, "xyz": 2}), wantW: "foo=0,bar=1,xyz=2", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			if err := tt.field.ValueString(w, nil); (err != nil) != tt.wantErr {
+				t.Errorf("Field.ValueString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotW := w.String(); gotW != tt.wantW {
+				t.Errorf("Field.ValueString() = %v, want %v", gotW, tt.wantW)
+			}
+		})
+	}
+}
+
 type testStringer struct {
 	s string
 }


### PR DESCRIPTION
#### Summary
The plain formatter no longer appends a trailing comma to slice and map fields. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55614
