### PR TITLE
Fix flaky test TestField_Map

### DIFF
--- a/field_test.go
+++ b/field_test.go
@@ -2,7 +2,10 @@ package logr
 
 import (
 	"bytes"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -111,17 +114,17 @@ func TestField_Array(t *testing.T) {
 
 func TestField_Map(t *testing.T) {
 	tests := []struct {
-		name    string
-		field   Field
-		wantW   string
-		wantErr bool
+		name       string
+		field      Field
+		wantW      string
+		wantCommas int
+		wantErr    bool
 	}{
 		{name: "nil", field: Map[map[string]any]("map", nil), wantW: "", wantErr: false},
-
 		{name: "empty", field: Map("map", map[string]any{}), wantW: "", wantErr: false},
 		{name: "one elements", field: Map("map", map[string]int{"foo": 0}), wantW: "foo=0", wantErr: false},
-		{name: "two elements", field: Map("map", map[string]int{"foo": 0, "bar": 1}), wantW: "foo=0,bar=1", wantErr: false},
-		{name: "three elements", field: Map("map", map[string]int{"foo": 0, "bar": 1, "xyz": 2}), wantW: "foo=0,bar=1,xyz=2", wantErr: false},
+		{name: "two elements", field: Map("map", map[string]int{"foo": 0, "bar": 1}), wantW: "foo=0,bar=1", wantCommas: 1, wantErr: false},
+		{name: "three elements", field: Map("map", map[string]int{"foo": 0, "bar": 1, "xyz": 2}), wantW: "foo=0,bar=1,xyz=2", wantCommas: 2, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -130,8 +133,19 @@ func TestField_Map(t *testing.T) {
 				t.Errorf("Field.ValueString() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if gotW := w.String(); gotW != tt.wantW {
-				t.Errorf("Field.ValueString() = %v, want %v", gotW, tt.wantW)
+			if tt.wantCommas == 0 {
+				if gotW := w.String(); gotW != tt.wantW {
+					t.Errorf("Field.ValueString() = %v, want %v", gotW, tt.wantW)
+				}
+			} else {
+				gotW := w.String()
+				if commas := strings.Count(gotW, ","); commas != tt.wantCommas {
+					t.Errorf("Got %d commas in %s, want %d", commas, gotW, tt.wantCommas)
+				}
+
+				gotElems := strings.Split(gotW, ",")
+				wantElems := strings.Split(tt.wantW, ",")
+				assert.ElementsMatch(t, gotElems, wantElems)
 			}
 		})
 	}


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/logr/pull/46  added a flaky test. The element order of `MapRange()` is not defined and can vary from run to run.


#### Ticket Link
https://github.com/mattermost/logr/pull/46
