### PR TITLE
Fix TCP target connection re-establishment issue

### DIFF
--- a/targets/tcp.go
+++ b/targets/tcp.go
@@ -92,6 +92,7 @@ func (tcp *Tcp) getConn(reporter func(err interface{})) (net.Conn, error) {
 		conn, err := tcp.dial(ctx)
 		if err != nil {
 			reporter(fmt.Errorf("log target %s connection error: %w", tcp.String(), err))
+			ch <- result{conn: nil, err: err}
 			return
 		}
 		tcp.conn = conn

--- a/targets/tcp_test.go
+++ b/targets/tcp_test.go
@@ -5,6 +5,7 @@ package targets
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mattermost/logr/v2"
 	"github.com/mattermost/logr/v2/formatters"
@@ -61,5 +62,100 @@ func TestNewTcpTarget(t *testing.T) {
 		for _, s := range data {
 			require.Contains(t, sdata, s)
 		}
+	})
+
+	t.Run("TCP connection recovery", func(t *testing.T) {
+		// Use a different port for the recovery test to avoid conflicts
+		recoveryPort := TestPort + 1
+		recoveryOpts := &TcpOptions{
+			IP:   Server,
+			Port: recoveryPort,
+		}
+
+		// First start with no server running
+		recoveryLgr, _ := logr.New()
+		tcp := NewTcpTarget(recoveryOpts)
+
+		err := recoveryLgr.AddTarget(tcp, "tcp_recovery_test", filter, formatter, 1000)
+		require.NoError(t, err)
+
+		recoveryLogger := recoveryLgr.NewLogger().With(logr.String("name", "recovery"))
+
+		// Try to log something when no server is running (will be queued)
+		recoveryLogger.Info("buffered")
+
+		// Now start the server
+		buf := &test.Buffer{}
+		server, err := test.NewSocketServer(recoveryPort, buf)
+		require.NoError(t, err)
+
+		// Flush logs to ensure delivery
+		err = recoveryLgr.Flush()
+		require.NoError(t, err)
+
+		// Wait for connection to be established
+		err = server.WaitForAnyConnection()
+		require.NoError(t, err)
+
+		// Log a message after starting
+		recoveryLogger.Info("pre-stop")
+
+		// Flush to ensure messages are processed
+		err = recoveryLgr.Flush()
+		require.NoError(t, err)
+
+		// Short wait for flush to settle
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify messages were received
+		sdata := buf.String()
+		require.Contains(t, sdata, "buffered")
+		require.Contains(t, sdata, "pre-stop")
+
+		// Close the server to simulate connection loss
+		err = server.StopServer(false)
+		require.NoError(t, err)
+
+		// Wait for all connections to close
+		time.Sleep(1 * time.Second)
+
+		// Try logging with server down
+		recoveryLogger.Info("during-stop")
+
+		// Wait to ensure we try to log while server is down
+		// Important: this delay needs to be long enough to
+		// trigger at least one call to tcp dial()
+		time.Sleep(500 * time.Millisecond)
+
+		// Start server again to test reconnection
+		buf2 := &test.Buffer{}
+		server2, err := test.NewSocketServer(recoveryPort, buf2)
+		require.NoError(t, err)
+
+		// Wait for any connections
+		err = server2.WaitForAnyConnection()
+		require.NoError(t, err)
+
+		// Try logging with server up again
+		recoveryLogger.Info("post-stop")
+
+		// Flush logs to ensure delivery
+		err = recoveryLgr.Flush()
+		require.NoError(t, err)
+
+		// Short wait for flush to settle
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify at least some messages got through
+		sdata2 := buf2.String()
+		require.Contains(t, sdata2, "during-stop")
+		require.Contains(t, sdata2, "post-stop")
+
+		// Clean up
+		err = recoveryLgr.Shutdown()
+		require.NoError(t, err)
+
+		err = server2.StopServer(false)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
#### Summary

This PR fixes a bug in the `getConn` method that caused the TCP target to fail at re-establishing connections after they were closed remotely. This bug was triggered if the remote target is down, and we try to log an event at the same time.

#### Ticket Link
Fixes #51

#### Test Results

This PR introduces a new test to verify the bugfix introduced in `targets/tcp.go`. With the fix disabled, the test fails with the following output:
```
=== RUN   TestNewTcpTarget
=== RUN   TestNewTcpTarget/TCP_connection_recovery
log target TcpTarget[localhost:18068] set write deadline error: set tcp 127.0.0.1:36330: use of closed network connection
log target TcpTarget[localhost:18068] write error: write tcp 127.0.0.1:36330->127.0.0.1:18068: use of closed network connection
log target TcpTarget[localhost:18068] connection error: dial tcp 127.0.0.1:18068: connect: connection refused
    tcp_test.go:137: 
        	Error Trace:	tcp_test.go:137
        	Error:      	Received unexpected error:
        	            	wait for any connection timed out
        	Test:       	TestNewTcpTarget/TCP_connection_recovery
--- FAIL: TestNewTcpTarget (16.61s)
    --- FAIL: TestNewTcpTarget/TCP_connection_recovery (16.61s)
FAIL
FAIL	github.com/mattermost/logr/v2/targets	16.612s
FAIL
```

With the fix enabled, the test succeeds with the following output:

```
=== RUN   TestNewTcpTarget
=== RUN   TestNewTcpTarget/TCP_connection_recovery
log target TcpTarget[localhost:18068] set write deadline error: set tcp 127.0.0.1:40986: use of closed network connection
log target TcpTarget[localhost:18068] write error: write tcp 127.0.0.1:40986->127.0.0.1:18068: use of closed network connection
log target TcpTarget[localhost:18068] connection error: dial tcp 127.0.0.1:18068: connect: connection refused
log target TcpTarget[localhost:18068] connection error: dial tcp 127.0.0.1:18068: connect: connection refused
log target TcpTarget[localhost:18068] connection error: dial tcp 127.0.0.1:18068: connect: connection refused
log target TcpTarget[localhost:18068] connection error: dial tcp 127.0.0.1:18068: connect: connection refused
log target TcpTarget[localhost:18068] connection error: dial tcp 127.0.0.1:18068: connect: connection refused
log target TcpTarget[localhost:18068] connection error: dial tcp 127.0.0.1:18068: connect: connection refused
--- PASS: TestNewTcpTarget (2.02s)
    --- PASS: TestNewTcpTarget/TCP_connection_recovery (2.02s)
PASS
ok  	github.com/mattermost/logr/v2/targets	2.028s
```

The `connection error` messages are expected in the output. The server is down while we are trying to log events.

**Note:** For the test to function properly, a bug was also fixed in the test SocketServer object to ensure we properly close all connections when the server is stopped.
