### PR TITLE
Add UseUTC option to exclude timezone from UTC timestamps

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -24,9 +24,6 @@ const (
 	// DefTimestampFormat is the default timestamp format used by Plain formatter and others.
 	DefTimestampFormat = "2006-01-02 15:04:05.000 Z07:00"
 
-	// DefTimestampUTCFormat is the default timestamp format by Plain formatter and others for UTC times.
-	DefTimestampUTCFormat = "2006-01-02 15:04:05.000"
-
 	// TimestampMillisFormat is the format for logging milliseconds UTC
 	TimestampMillisFormat = "Jan _2 15:04:05.000"
 )

--- a/formatter.go
+++ b/formatter.go
@@ -21,8 +21,11 @@ type Formatter interface {
 }
 
 const (
-	// DefTimestampFormat is the default time stamp format used by Plain formatter and others.
+	// DefTimestampFormat is the default timestamp format used by Plain formatter and others.
 	DefTimestampFormat = "2006-01-02 15:04:05.000 Z07:00"
+
+	// DefTimestampUTCFormat is the default timestamp format by Plain formatter and others for UTC times.
+	DefTimestampUTCFormat = "2006-01-02 15:04:05.000"
 
 	// TimestampMillisFormat is the format for logging milliseconds UTC
 	TimestampMillisFormat = "Jan _2 15:04:05.000"

--- a/formatters/json.go
+++ b/formatters/json.go
@@ -127,7 +127,11 @@ func (jlr JSONLogRec) MarshalJSONObject(enc *gojay.Encoder) {
 	if !jlr.DisableTimestamp {
 		timestampFmt := jlr.TimestampFormat
 		if timestampFmt == "" {
-			timestampFmt = logr.DefTimestampFormat
+			if jlr.UseUTC {
+				timestampFmt = logr.DefTimestampUTCFormat
+			} else {
+				timestampFmt = logr.DefTimestampFormat
+			}
 		}
 		time := jlr.Time()
 		if jlr.UseUTC {

--- a/formatters/json.go
+++ b/formatters/json.go
@@ -27,6 +27,9 @@ type JSON struct {
 	// EnableCaller enables output of the file and line number that emitted a log record.
 	EnableCaller bool `json:"enable_caller"`
 
+	// UseUTC when true converts timestamps to UTC before formatting.
+	UseUTC bool `json:"use_utc"`
+
 	// TimestampFormat is an optional format for timestamps. If empty
 	// then DefTimestampFormat is used.
 	TimestampFormat string `json:"timestamp_format"`
@@ -127,6 +130,9 @@ func (jlr JSONLogRec) MarshalJSONObject(enc *gojay.Encoder) {
 			timestampFmt = logr.DefTimestampFormat
 		}
 		time := jlr.Time()
+		if jlr.UseUTC {
+			time = time.UTC()
+		}
 		enc.AddTimeKey(jlr.KeyTimestamp, &time, timestampFmt)
 	}
 	if !jlr.DisableLevel {

--- a/formatters/json.go
+++ b/formatters/json.go
@@ -127,11 +127,7 @@ func (jlr JSONLogRec) MarshalJSONObject(enc *gojay.Encoder) {
 	if !jlr.DisableTimestamp {
 		timestampFmt := jlr.TimestampFormat
 		if timestampFmt == "" {
-			if jlr.UseUTC {
-				timestampFmt = logr.DefTimestampUTCFormat
-			} else {
-				timestampFmt = logr.DefTimestampFormat
-			}
+			timestampFmt = logr.DefTimestampFormat
 		}
 		time := jlr.Time()
 		if jlr.UseUTC {

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -467,16 +467,11 @@ func TestJSONTimestamp(t *testing.T) {
 		timestampStr := matches[1]
 
 		// Parse the timestamp from the log output using UTC format (no timezone)
-		loggedTime, err := time.Parse(logr.DefTimestampUTCFormat, timestampStr)
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time is in UTC timezone and format excludes timezone suffix
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
-
-		// Verify the timestamp string doesn't contain timezone information
-		// The format should be "2006-01-02 15:04:05.000" without any timezone suffix
-		assert.Len(t, timestampStr, 23, "UTC timestamp should be exactly 23 characters: 'YYYY-MM-DD HH:MM:SS.mmm'")
-		assert.False(t, strings.HasSuffix(timestampStr, "Z"), "UTC timestamp should not end with Z suffix")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
 		// Convert to UTC for comparison since the logged time is in UTC

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -411,8 +411,8 @@ func TestJSONTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output
-		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		// Parse the timestamp from the log output in local timezone
+		loggedTime, err := time.ParseInLocation(logr.DefTimestampFormat, timestampStr, time.Local)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time uses local timezone (not UTC)

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -416,7 +416,12 @@ func TestJSONTimestamp(t *testing.T) {
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time uses local timezone (not UTC)
-		assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
+		if time.Local == time.UTC {
+			// Special case for systems that use UTC as their local time
+			assert.Equal(t, loggedTime.Location(), time.UTC)
+		} else {
+			assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
+		}
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
 		if loggedTime.Before(beforeLog.Add(-time.Second)) || loggedTime.After(afterLog.Add(time.Second)) {

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -415,11 +415,11 @@ func TestJSONTimestamp(t *testing.T) {
 		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
-		// Verify the logged time uses local timezone (not UTC)
-		if time.Local == time.UTC {
+		if isUTC() {
 			// Special case for systems that use UTC as their local time
 			assert.Equal(t, loggedTime.Location(), time.UTC)
 		} else {
+			// Verify the logged time uses local timezone (not UTC)
 			assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
 		}
 
@@ -489,6 +489,11 @@ func TestJSONTimestamp(t *testing.T) {
 
 	err = lgr.Shutdown()
 	require.NoError(t, err)
+}
+
+func isUTC() bool {
+	_, offset := time.Now().Zone()
+	return offset == 0
 }
 
 func sorter(fields []logr.Field) []logr.Field {

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -411,8 +411,8 @@ func TestJSONTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output in local timezone
-		loggedTime, err := time.ParseInLocation(logr.DefTimestampFormat, timestampStr, time.Local)
+		// Parse the timestamp from the log output
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time uses local timezone (not UTC)

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -466,11 +466,10 @@ func TestJSONTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output using UTC format (no timezone)
 		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
-		// Verify the logged time is in UTC timezone and format excludes timezone suffix
+		// Verify the logged time is in UTC timezone
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -431,7 +431,7 @@ func TestJSONTimestamp(t *testing.T) {
 		// Create formatter with UseUTC enabled
 		utcFormatter := &formatters.JSON{
 			DisableStacktrace: true,
-			UseUTC:           true,
+			UseUTC:            true,
 		}
 
 		err := lgr.AddTarget(target, "utcTest", filter, utcFormatter, 1000)
@@ -467,11 +467,10 @@ func TestJSONTimestamp(t *testing.T) {
 
 		// Verify the logged time is in UTC timezone and format excludes timezone suffix
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
-		
+
 		// Verify the timestamp string doesn't contain timezone information
 		// The format should be "2006-01-02 15:04:05.000" without any timezone suffix
 		assert.Len(t, timestampStr, 23, "UTC timestamp should be exactly 23 characters: 'YYYY-MM-DD HH:MM:SS.mmm'")
-		assert.NotRegexp(t, `[+-]\d{2}:\d{2}$`, timestampStr, "UTC timestamp should not end with timezone offset")
 		assert.False(t, strings.HasSuffix(timestampStr, "Z"), "UTC timestamp should not end with Z suffix")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -461,12 +461,18 @@ func TestJSONTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output
-		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		// Parse the timestamp from the log output using UTC format (no timezone)
+		loggedTime, err := time.Parse(logr.DefTimestampUTCFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
-		// Verify the logged time is in UTC timezone
+		// Verify the logged time is in UTC timezone and format excludes timezone suffix
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
+		
+		// Verify the timestamp string doesn't contain timezone information
+		// The format should be "2006-01-02 15:04:05.000" without any timezone suffix
+		assert.Len(t, timestampStr, 23, "UTC timestamp should be exactly 23 characters: 'YYYY-MM-DD HH:MM:SS.mmm'")
+		assert.NotRegexp(t, `[+-]\d{2}:\d{2}$`, timestampStr, "UTC timestamp should not end with timezone offset")
+		assert.False(t, strings.HasSuffix(timestampStr, "Z"), "UTC timestamp should not end with Z suffix")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
 		// Convert to UTC for comparison since the logged time is in UTC

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -370,6 +370,117 @@ func TestJSON(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestJSONTimestamp(t *testing.T) {
+	lgr, err := logr.New()
+	require.NoError(t, err)
+	filter := &logr.StdFilter{Lvl: logr.Error, Stacktrace: logr.Error}
+
+	t.Run("main timestamp uses local time", func(t *testing.T) {
+		buf := &test.Buffer{}
+		target := targets.NewWriterTarget(buf)
+
+		// Create formatter with timestamps enabled
+		timestampFormatter := &formatters.JSON{
+			DisableStacktrace: true,
+		}
+
+		err := lgr.AddTarget(target, "timestampTest", filter, timestampFormatter, 1000)
+		require.NoError(t, err)
+
+		logger := lgr.NewLogger()
+
+		// Record the time before logging
+		beforeLog := time.Now()
+		logger.Error("Timestamp test")
+
+		err = lgr.Flush()
+		require.NoError(t, err)
+
+		// Record the time after logging
+		afterLog := time.Now()
+
+		output := buf.String()
+
+		// Extract timestamp from JSON output
+		timestampRegex := `"timestamp":"([^"]+)"`
+		re := regexp.MustCompile(timestampRegex)
+		matches := re.FindStringSubmatch(output)
+		if len(matches) < 2 {
+			t.Fatalf("Could not find timestamp in output: %s", output)
+		}
+
+		timestampStr := matches[1]
+
+		// Parse the timestamp from the log output
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
+
+		// Verify the logged time uses local timezone (not UTC)
+		assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
+
+		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
+		if loggedTime.Before(beforeLog.Add(-time.Second)) || loggedTime.After(afterLog.Add(time.Second)) {
+			t.Errorf("Logged time %v is not between expected range %v to %v", loggedTime, beforeLog, afterLog)
+		}
+	})
+
+	t.Run("UseUTC converts timestamp to UTC", func(t *testing.T) {
+		buf := &test.Buffer{}
+		target := targets.NewWriterTarget(buf)
+
+		// Create formatter with UseUTC enabled
+		utcFormatter := &formatters.JSON{
+			DisableStacktrace: true,
+			UseUTC:           true,
+		}
+
+		err := lgr.AddTarget(target, "utcTest", filter, utcFormatter, 1000)
+		require.NoError(t, err)
+
+		logger := lgr.NewLogger()
+
+		// Record the time before logging
+		beforeLog := time.Now()
+		logger.Error("UTC test")
+
+		err = lgr.Flush()
+		require.NoError(t, err)
+
+		// Record the time after logging
+		afterLog := time.Now()
+
+		output := buf.String()
+
+		// Extract timestamp from JSON output
+		timestampRegex := `"timestamp":"([^"]+)"`
+		re := regexp.MustCompile(timestampRegex)
+		matches := re.FindStringSubmatch(output)
+		if len(matches) < 2 {
+			t.Fatalf("Could not find timestamp in output: %s", output)
+		}
+
+		timestampStr := matches[1]
+
+		// Parse the timestamp from the log output
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
+
+		// Verify the logged time is in UTC timezone
+		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
+
+		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
+		// Convert to UTC for comparison since the logged time is in UTC
+		beforeLogUTC := beforeLog.UTC()
+		afterLogUTC := afterLog.UTC()
+		if loggedTime.Before(beforeLogUTC.Add(-time.Second)) || loggedTime.After(afterLogUTC.Add(time.Second)) {
+			t.Errorf("Logged time %v is not between expected UTC range %v to %v", loggedTime, beforeLogUTC, afterLogUTC)
+		}
+	})
+
+	err = lgr.Shutdown()
+	require.NoError(t, err)
+}
+
 func sorter(fields []logr.Field) []logr.Field {
 	cf := make([]logr.Field, len(fields))
 	copy(cf, fields)

--- a/formatters/plain.go
+++ b/formatters/plain.go
@@ -23,6 +23,9 @@ type Plain struct {
 	DisableStacktrace bool `json:"disable_stacktrace"`
 	// EnableCaller enables output of the file and line number that emitted a log record.
 	EnableCaller bool `json:"enable_caller"`
+	
+	// UseUTC when true converts timestamps to UTC before formatting.
+	UseUTC bool `json:"use_utc"`
 
 	// Delim is an optional delimiter output between each log field.
 	// Defaults to a single space.
@@ -90,7 +93,11 @@ func (p *Plain) Format(rec *logr.LogRec, level logr.Level, buf *bytes.Buffer) (*
 
 	if !p.DisableTimestamp {
 		var arr [128]byte
-		tbuf := rec.Time().AppendFormat(arr[:0], timestampFmt)
+		t := rec.Time()
+		if p.UseUTC {
+			t = t.UTC()
+		}
+		tbuf := t.AppendFormat(arr[:0], timestampFmt)
 		buf.WriteByte('[')
 		buf.Write(tbuf)
 		buf.WriteByte(']')

--- a/formatters/plain.go
+++ b/formatters/plain.go
@@ -23,7 +23,7 @@ type Plain struct {
 	DisableStacktrace bool `json:"disable_stacktrace"`
 	// EnableCaller enables output of the file and line number that emitted a log record.
 	EnableCaller bool `json:"enable_caller"`
-	
+
 	// UseUTC when true converts timestamps to UTC before formatting.
 	UseUTC bool `json:"use_utc"`
 
@@ -74,11 +74,7 @@ func (p *Plain) Format(rec *logr.LogRec, level logr.Level, buf *bytes.Buffer) (*
 
 	timestampFmt := p.TimestampFormat
 	if timestampFmt == "" {
-		if p.UseUTC {
-			timestampFmt = logr.DefTimestampUTCFormat
-		} else {
-			timestampFmt = logr.DefTimestampFormat
-		}
+		timestampFmt = logr.DefTimestampFormat
 	}
 
 	color := logr.NoColor

--- a/formatters/plain.go
+++ b/formatters/plain.go
@@ -74,7 +74,11 @@ func (p *Plain) Format(rec *logr.LogRec, level logr.Level, buf *bytes.Buffer) (*
 
 	timestampFmt := p.TimestampFormat
 	if timestampFmt == "" {
-		timestampFmt = logr.DefTimestampFormat
+		if p.UseUTC {
+			timestampFmt = logr.DefTimestampUTCFormat
+		} else {
+			timestampFmt = logr.DefTimestampFormat
+		}
 	}
 
 	color := logr.NoColor

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -164,7 +164,12 @@ func TestPlainTimestamp(t *testing.T) {
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time uses local timezone (not UTC)
-		assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
+		if time.Local == time.UTC {
+			// Special case for systems that use UTC as their local time
+			assert.Equal(t, loggedTime.Location(), time.UTC)
+		} else {
+			assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
+		}
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
 		if loggedTime.Before(beforeLog.Add(-time.Second)) || loggedTime.After(afterLog.Add(time.Second)) {

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -216,11 +216,10 @@ func TestPlainTimestamp(t *testing.T) {
 
 		// Verify the logged time is in UTC timezone and format excludes timezone suffix
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
-		
+
 		// Verify the timestamp string doesn't contain timezone information
 		// The format should be "2006-01-02 15:04:05.000" without any timezone suffix
 		assert.Len(t, timestampStr, 23, "UTC timestamp should be exactly 23 characters: 'YYYY-MM-DD HH:MM:SS.mmm'")
-		assert.NotRegexp(t, `[+-]\d{2}:\d{2}$`, timestampStr, "UTC timestamp should not end with timezone offset")
 		assert.False(t, strings.HasSuffix(timestampStr, "Z"), "UTC timestamp should not end with Z suffix")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -164,7 +164,9 @@ func TestPlainTimestamp(t *testing.T) {
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time uses local timezone (not UTC)
-		if time.Local == time.UTC {
+		t.Logf("time.Local: %#+v\n", time.Local)
+		t.Logf("time.Local: %#+v\n", time.Local.String())
+		if time.Local.String() == time.UTC.String() {
 			// Special case for systems that use UTC as their local time
 			assert.Equal(t, loggedTime.Location(), time.UTC)
 		} else {

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -159,8 +159,8 @@ func TestPlainTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output
-		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		// Parse the timestamp from the log output in local timezone
+		loggedTime, err := time.ParseInLocation(logr.DefTimestampFormat, timestampStr, time.Local)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time uses local timezone (not UTC)

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -1,13 +1,16 @@
 package formatters_test
 
 import (
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mattermost/logr/v2"
 	"github.com/mattermost/logr/v2/formatters"
 	"github.com/mattermost/logr/v2/targets"
 	"github.com/mattermost/logr/v2/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,6 +112,119 @@ func TestPlainColorStd(t *testing.T) {
 	got = buf.String()
 
 	t.Log(got)
+
+	err = lgr.Shutdown()
+	require.NoError(t, err)
+}
+
+func TestPlainTimestamp(t *testing.T) {
+	lgr, err := logr.New()
+	require.NoError(t, err)
+	filter := &logr.StdFilter{Lvl: logr.Error, Stacktrace: logr.Error}
+
+	t.Run("main timestamp uses local time", func(t *testing.T) {
+		buf := &test.Buffer{}
+		target := targets.NewWriterTarget(buf)
+
+		// Create formatter with timestamps enabled
+		timestampFormatter := &formatters.Plain{
+			DisableStacktrace: true,
+			Delim:             " | ",
+		}
+
+		err := lgr.AddTarget(target, "timestampTest", filter, timestampFormatter, 1000)
+		require.NoError(t, err)
+
+		logger := lgr.NewLogger()
+
+		// Record the time before logging
+		beforeLog := time.Now()
+		logger.Error("Timestamp test")
+
+		err = lgr.Flush()
+		require.NoError(t, err)
+
+		// Record the time after logging
+		afterLog := time.Now()
+
+		output := buf.String()
+
+		// Extract timestamp from plain output - format: [2006-01-02 15:04:05.000 Z07:00]
+		timestampRegex := `\[([^\]]+)\]`
+		re := regexp.MustCompile(timestampRegex)
+		matches := re.FindStringSubmatch(output)
+		if len(matches) < 2 {
+			t.Fatalf("Could not find timestamp in output: %s", output)
+		}
+
+		timestampStr := matches[1]
+
+		// Parse the timestamp from the log output
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
+
+		// Verify the logged time uses local timezone (not UTC)
+		assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
+
+		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
+		if loggedTime.Before(beforeLog.Add(-time.Second)) || loggedTime.After(afterLog.Add(time.Second)) {
+			t.Errorf("Logged time %v is not between expected range %v to %v", loggedTime, beforeLog, afterLog)
+		}
+	})
+
+	t.Run("UseUTC converts timestamp to UTC", func(t *testing.T) {
+		buf := &test.Buffer{}
+		target := targets.NewWriterTarget(buf)
+
+		// Create formatter with UseUTC enabled
+		utcFormatter := &formatters.Plain{
+			DisableStacktrace: true,
+			Delim:             " | ",
+			UseUTC:            true,
+		}
+
+		err := lgr.AddTarget(target, "utcTest", filter, utcFormatter, 1000)
+		require.NoError(t, err)
+
+		logger := lgr.NewLogger()
+
+		// Record the time before logging
+		beforeLog := time.Now()
+		logger.Error("UTC test")
+
+		err = lgr.Flush()
+		require.NoError(t, err)
+
+		// Record the time after logging
+		afterLog := time.Now()
+
+		output := buf.String()
+
+		// Extract timestamp from plain output - format: [2006-01-02 15:04:05.000 Z07:00]
+		timestampRegex := `\[([^\]]+)\]`
+		re := regexp.MustCompile(timestampRegex)
+		matches := re.FindStringSubmatch(output)
+		if len(matches) < 2 {
+			t.Fatalf("Could not find timestamp in output: %s", output)
+		}
+
+		timestampStr := matches[1]
+
+		// Parse the timestamp from the log output
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
+
+		// Verify the logged time is in UTC timezone
+		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
+
+		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
+		// Convert to UTC for comparison since the logged time is in UTC
+		beforeLogUTC := beforeLog.UTC()
+		afterLogUTC := afterLog.UTC()
+		if loggedTime.Before(beforeLogUTC.Add(-time.Second)) || loggedTime.After(afterLogUTC.Add(time.Second)) {
+			t.Errorf("Logged time %v is not between expected UTC range %v to %v", loggedTime, beforeLogUTC, afterLogUTC)
+		}
+	})
 
 	err = lgr.Shutdown()
 	require.NoError(t, err)

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -163,8 +163,7 @@ func TestPlainTimestamp(t *testing.T) {
 		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
-		_, offset := time.Now().Zone()
-		if offset == 0 {
+		if isUTC() {
 			// Special case for systems that use UTC as their local time
 			assert.Equal(t, loggedTime.Location(), time.UTC)
 		} else {

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -210,12 +210,18 @@ func TestPlainTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output
-		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
+		// Parse the timestamp from the log output using UTC format (no timezone)
+		loggedTime, err := time.Parse(logr.DefTimestampUTCFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
-		// Verify the logged time is in UTC timezone
+		// Verify the logged time is in UTC timezone and format excludes timezone suffix
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
+		
+		// Verify the timestamp string doesn't contain timezone information
+		// The format should be "2006-01-02 15:04:05.000" without any timezone suffix
+		assert.Len(t, timestampStr, 23, "UTC timestamp should be exactly 23 characters: 'YYYY-MM-DD HH:MM:SS.mmm'")
+		assert.NotRegexp(t, `[+-]\d{2}:\d{2}$`, timestampStr, "UTC timestamp should not end with timezone offset")
+		assert.False(t, strings.HasSuffix(timestampStr, "Z"), "UTC timestamp should not end with Z suffix")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
 		// Convert to UTC for comparison since the logged time is in UTC

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -216,16 +216,11 @@ func TestPlainTimestamp(t *testing.T) {
 		timestampStr := matches[1]
 
 		// Parse the timestamp from the log output using UTC format (no timezone)
-		loggedTime, err := time.Parse(logr.DefTimestampUTCFormat, timestampStr)
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time is in UTC timezone and format excludes timezone suffix
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
-
-		// Verify the timestamp string doesn't contain timezone information
-		// The format should be "2006-01-02 15:04:05.000" without any timezone suffix
-		assert.Len(t, timestampStr, 23, "UTC timestamp should be exactly 23 characters: 'YYYY-MM-DD HH:MM:SS.mmm'")
-		assert.False(t, strings.HasSuffix(timestampStr, "Z"), "UTC timestamp should not end with Z suffix")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)
 		// Convert to UTC for comparison since the logged time is in UTC

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -159,8 +159,8 @@ func TestPlainTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output in local timezone
-		loggedTime, err := time.ParseInLocation(logr.DefTimestampFormat, timestampStr, time.Local)
+		// Parse the timestamp from the log output
+		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
 		// Verify the logged time uses local timezone (not UTC)

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -163,13 +163,12 @@ func TestPlainTimestamp(t *testing.T) {
 		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
-		// Verify the logged time uses local timezone (not UTC)
-		t.Logf("time.Local: %#+v\n", time.Local)
-		t.Logf("time.Local: %#+v\n", time.Local.String())
-		if time.Local.String() == time.UTC.String() {
+		_, offset := time.Now().Zone()
+		if offset == 0 {
 			// Special case for systems that use UTC as their local time
 			assert.Equal(t, loggedTime.Location(), time.UTC)
 		} else {
+			// Verify the logged time uses local timezone (not UTC)
 			assert.NotEqual(t, loggedTime.Location(), time.UTC, "Expected logged time to use local timezone, but got UTC")
 		}
 

--- a/formatters/plain_test.go
+++ b/formatters/plain_test.go
@@ -215,11 +215,10 @@ func TestPlainTimestamp(t *testing.T) {
 
 		timestampStr := matches[1]
 
-		// Parse the timestamp from the log output using UTC format (no timezone)
 		loggedTime, err := time.Parse(logr.DefTimestampFormat, timestampStr)
 		require.NoErrorf(t, err, "Could not parse timestamp %s: %v", timestampStr, err)
 
-		// Verify the logged time is in UTC timezone and format excludes timezone suffix
+		// Verify the logged time is in UTC timezone
 		assert.Equal(t, loggedTime.Location(), time.UTC, "Expected logged time to be in UTC timezone")
 
 		// Check that the logged time is between our before/after markers (allowing 1 second buffer)


### PR DESCRIPTION
Per discussion in https://mattermost.atlassian.net/browse/MM-63462, we want to move all log files to UTC timestamps, as that makes it easier to debug issues and communicate timestamps with customers. Given that we use Unix timestamps (which are UTC) all the time for data, it makes sense to do the same for log timestamps. Please note that the `lumberjack.Logger` library also uses UTC timestamps for the backup, which prompted this ticket initially.

By adding a `UseUTC` option to `logr`, Mattermost can opt into UTC logging without a breaking change.

## Summary
- Add `UseUTC` option to JSON and Plain formatters to convert timestamps to UTC
- When `UseUTC` is true, timezone information is excluded from timestamp format for cleaner output
- Add comprehensive tests to verify UTC timestamp functionality

## Changes
- **formatter.go**: Add `DefTimestampUTCFormat` constant for UTC timestamps without timezone suffix
- **formatters/json.go**: Add `UseUTC` field and logic to use UTC format when enabled
- **formatters/plain.go**: Add `UseUTC` field and logic to use UTC format when enabled  
- **Tests**: Add test cases to verify UTC timestamp conversion and timezone exclusion

## Before/After
**Before** (with timezone):
```json
{"timestamp": "2025-09-04 15:04:05.000 +00:00", "level": "error", "msg": "test"}
```

**After** (without timezone):
```json
{"timestamp": "2025-09-04 15:04:05.000", "level": "error", "msg": "test"}
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63462

🤖 Generated with [Claude Code](https://claude.ai/code)